### PR TITLE
Lazy column options

### DIFF
--- a/spec/audited/adapters/active_record/auditor_spec.rb
+++ b/spec/audited/adapters/active_record/auditor_spec.rb
@@ -18,12 +18,13 @@ describe Audited::Auditor, :adapter => :active_record do
     end
 
     it "should be configurable which attributes are not audited" do
-      Audited.ignored_attributes = ['delta', 'top_secret', 'created_at']
-      class Secret < ::ActiveRecord::Base
-        audited
-      end
+      with_ignored_attributes(['delta', 'top_secret', 'created_at']) do
+        class Secret < ::ActiveRecord::Base
+          audited
+        end
 
-      Secret.non_audited_columns.should include('delta', 'top_secret', 'created_at')
+        Secret.non_audited_columns.should include('delta', 'top_secret', 'created_at')
+      end
     end
 
     it "should not save non-audited columns" do

--- a/spec/audited/adapters/mongo_mapper/auditor_spec.rb
+++ b/spec/audited/adapters/mongo_mapper/auditor_spec.rb
@@ -18,13 +18,14 @@ describe Audited::Auditor, :adapter => :mongo_mapper do
     end
 
     it "should be configurable which attributes are not audited" do
-      Audited.ignored_attributes = ['delta', 'top_secret', 'created_at']
-      class Secret
-        include MongoMapper::Document
-        audited
-      end
+      with_ignored_attributes(['delta', 'top_secret', 'created_at']) do
+        class Secret
+          include MongoMapper::Document
+          audited
+        end
 
-      Secret.non_audited_columns.should include('delta', 'top_secret', 'created_at')
+        Secret.non_audited_columns.should include('delta', 'top_secret', 'created_at')
+      end
     end
 
     it "should not save non-audited columns" do

--- a/spec/audited_spec_helpers.rb
+++ b/spec/audited_spec_helpers.rb
@@ -28,4 +28,12 @@ module AuditedSpecHelpers
     create_versions(n, true)
   end
 
+  def with_ignored_attributes(attributes)
+    old_attributes = Audited.ignored_attributes
+    Audited.ignored_attributes = attributes
+    yield
+  ensure
+    Audited.ignored_attributes = old_attributes
+  end
+
 end


### PR DESCRIPTION
Initialize column options lazily to avoid problems when requiring audited models early
